### PR TITLE
Changed: Process open allow list of arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ class KeywordQueryEventListener(EventListener):
 
 class ItemEnterEventListener(EventListener):
     def on_event(self, event, extension):
-        subprocess.Popen([extension.preferences['firefox_cmd'], '-p', event.get_data()], start_new_session=True)
+        subprocess.Popen([*extension.preferences['firefox_cmd'].split(), '-p', event.get_data()], start_new_session=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows `firefox_cmd` to be a list of a command with arguments, which enables for example `flatpak run org.mozilla.firefox` to work.

I've merged it to [master on my fork](pmodin/ulauncher-firefox-profiles) if you want to try it out before merge.